### PR TITLE
Settings gear w/ Font Awesome & Mio theme update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,30 +45,61 @@ We try to make sure vichan is compatible with all major web servers. vichan does
 
 Contributing
 ------------
-You can contribute to vichan by:
+You can contribute to vichan-plus by:
 *	Developing patches/improvements/translations and using GitHub to submit pull requests
 *	Providing feedback and suggestions
 *	Writing/editing documentation
 
 Installation
 -------------
-1.	Get the latest development version with:
+1.	Get the latest development version & install to your web server directory with:
+   
+        git clone git://github.com/systemd1337/vichan-plus
+3.  For Debian based operating systems, install the required packages:
 
-        git clone git://github.com/vichan-devel/vichan.git
+        sudo apt install php7.4-mysql, php7.4-mbstring, php7.4-redis, php7.4-imagick, php7.4-igbinary, php7.4-gmp, php7.4-bcmath, php7.4-curl, php7.4-gd, php7.4-zip, php7.4-imap, php7.4-ldap, php7.4-bz2, php7.4-ssh2, php-phpseclib, php7.4-common, php7.4-json, php7.4-xml, php7.4-dev, libsmbclient-dev, php-pear
 
-2.	run ```composer install``` inside the directory	
-3.	Navigate to ```install.php``` in your web browser and follow the
+4.	run ```composer install``` inside the vichan-plus directory	
+5.	Navigate to ```install.php``` in your web browser and follow the
 	prompts.
-4.	vichan should now be installed. Log in to ```mod.php``` with the
+6.	vichan should now be installed. Log in to ```mod.php``` with the
 	default username and password combination: **admin / password**.
 
 Please remember to change the administrator account password.
 
 See also: [Configuration Basics](https://github.com/vichan-devel/vichan/wiki/config).
 
+*Optionally, enable additional JavaScript by adding the following definitions to `inc/instance-config.php`*:
+```js
+$config['additional_javascript'][] = 'js/jquery.min.js';
+$config['additional_javascript'][] = 'js/mobile-style.js';
+$config['additional_javascript'][] = 'js/download-original.js';
+$config['additional_javascript'][] = 'js/expand-all-images.js';
+$config['additional_javascript'][] = 'js/expand-too-long.js';
+$config['additional_javascript'][] = 'js/ajax.js';
+$config['additional_javascript'][] = 'js/post-hover.js';
+$config['additional_javascript'][] = 'js/quick-reply.js';
+$config['additional_javascript'][] = 'js/show-backlinks.js';
+$config['additional_javascript'][] = 'js/show-own-posts.js';
+$config['additional_javascript'][] = 'js/thread-stats.js';
+$config['additional_javascript'][] = 'js/jquery-ui.custom.min.js';
+$config['additional_javascript'][] = 'js/show-backlinks.js';
+$config['additional_javascript'][] = 'js/wPaint/8ch.js';
+$config['additional_javascript'][] = 'js/wpaint.js';
+$config['additional_javascript'][] = 'js/upload-selection.js';
+$config['additional_javascript'][] = 'js/options.js';
+$config['additional_javascript'][] = 'js/local-time.js';
+$config['additional_javascript'][] = 'js/charcount.js';
+$config['additional_javascript'][] = 'js/hide-threads.js';
+$config['additional_javascript'][] = 'js/post-menu.js';
+$config['additional_javascript'][] = 'js/fix-report-delete-submit.js';
+$config['additional_javascript'][] = 'js/style-select.js';
+$config['additional_javascript'][] = 'js/options/general.js';
+```
+
 Upgrade
 -------
-To upgrade from any version of Tinyboard or vichan:
+To upgrade from any version of vichan-plus:
 
 Either run ```git pull``` to update your files, if you used git, or
 backup your ```inc/instance-config.php```, replace all your files in place
@@ -88,7 +119,7 @@ Demo with the most updated version of [Vichan](https://vichan.27chan.org).
 
 Support
 --------
-vichan is still beta software -- there are bound to be bugs. If you find a
+vichan-plus is still beta software -- there are bound to be bugs. If you find a
 bug, please report it.
 
 CLI tools

--- a/inc/config.php
+++ b/inc/config.php
@@ -1481,14 +1481,14 @@
 
 	// "## Mod" makes everything purple, including the name and tripcode:
 	$config['custom_capcode']['Mod'] = array(
-		'<span style="display: inline-block; font-size: 80 font-weight: normal; background: #4B0082	; color: #ffffff; padding: 2px 5px 2px 5px; margin-left: 2px; margin-right: 2px; margin-bottom: 2px; border-radius: 4px;}color:purple">## Mod</span>',
+		'<span style="display: inline-block; font-weight: normal; background: #4B0082; color: #ffffff; padding: 2px 5px 2px 5px; margin-left: 2px; margin-right: 2px; margin-bottom: 2px; border-radius: 4px; color:white;">## Mod</span>',
 		'color:purple', // Change name style; optional
 		'color:purple' // Change tripcode style; optional
 	);
 
 	// "## Admin" makes everything red and bold, including the name and tripcode:
 	$config['custom_capcode']['Admin'] = array(
-		'<span style="display: inline-block; font-size: 80 font-weight: normal; background: #6CB4EE; color: #ffffff; padding: 2px 5px 2px 5px; margin-left: 2px; margin-right: 2px; margin-bottom: 2px; border-radius: 4px;}color:blue">## Administrator</span>',
+		'<span style="display: inline-block; font-weight: normal; background: #6CB4EE; color: #ffffff; padding: 2px 5px 2px 5px; margin-left: 2px; margin-right: 2px; margin-bottom: 2px; border-radius: 4px; color:blue;">## Administrator</span>',
 		'color:blue;font-weight:bold', // Change name style; optional
 		'color:blue;font-weight:bold' // Change tripcode style; optional
 	);

--- a/js/options.js
+++ b/js/options.js
@@ -103,7 +103,7 @@ options_tablist = $("<div id='options_tablist'></div>").appendTo(options_div);
 
 
 $(function(){
-  options_button = $("<a href='javascript:void(0)' title='"+_("Options")+"'>["+_("Settings ⚙")+"]</a>").css("float", "right");
+  options_button = $("<a href='javascript:void(0)' title='"+_("Options")+"'>["+_("Settings <i aria-hidden='true' class='fa fa-gear'></i>")+"]</a>").css("float", "right");
 
   if ($(".boardlist.compact-boardlist").length) {
     options_button.addClass("cb-item cb-fa").html("<i class='fa fa-gear'></i>");

--- a/stylesheets/mio.css
+++ b/stylesheets/mio.css
@@ -244,3 +244,27 @@ fieldset {
 fieldset > legend {
 	font-weight: bold;
 }
+
+/*
+	Changing button styling to match with Mio theme.
+	TODO: Button styling for file upload is still browser default.
+*/
+input[type="button"], input[type="submit"], button {
+	color: white;
+	background-color: #6156a7;
+	border: none;
+	padding: 2px 6px;
+	border-radius: 2px;
+	margin: 0px 2px;
+}
+
+input[type="text"], input[type="number"], textarea, select {
+	color: black;
+	border: 1px solid #6156a7;
+	border-radius: 2px;
+	background-color: #d9e1f4;
+}
+
+/* Spacing for hamburger menu beside posters name. */
+.post-btn {
+	padding-right: 7px;

--- a/stylesheets/mio.css
+++ b/stylesheets/mio.css
@@ -268,3 +268,4 @@ input[type="text"], input[type="number"], textarea, select {
 /* Spacing for hamburger menu beside posters name. */
 .post-btn {
 	padding-right: 7px;
+}


### PR DESCRIPTION
- Updates to Mio theme button and input colors. More information in commit description, though maybe a different color would look better than this.
- Gear icon for settings changed to use Font Awesome rather than ⚙ unicode. Its more consistent with the icons used on the header.
- EDIT: Fixed styling on cap-code for Admin and Moderator in config.php, colors were not readable for Mod.

Gear icon change effects `js/options.js` and not just Mio theme.

## Before
![image](https://github.com/systemd1337/vichan-plus/assets/154212868/e75404cb-5762-4262-9479-deaef54eac00)
![image](https://github.com/systemd1337/vichan-plus/assets/154212868/19cbb7c7-1d45-4e93-8782-50ded064461d)
## After
![image](https://github.com/systemd1337/vichan-plus/assets/154212868/9a0c6e1a-7fae-4e55-b8f7-e9a784483892)
![image](https://github.com/systemd1337/vichan-plus/assets/154212868/d1a90688-fe45-46a8-85f2-057dbc41935c)
