### PR TITLE
Update JPG Exif API

### DIFF
--- a/templates/post/image_identification.html
+++ b/templates/post/image_identification.html
@@ -4,7 +4,7 @@
 			<a href="http://imgops.com/{{ config.domain }}{{ config.uri_img }}{{ file.file }}" target="_blank">ImgOps</a> 
 		{% endif %}
 		{% if config.image_identification_exif and file.file|extension == 'jpg' %}
-			<a href="http://exif.int21h.win/?url={{ config.domain }}{{ config.uri_img }}{{ file.file }}" target="_blank">Exif</a> 
+			<a href="https://jimpl.com/?url={{ config.domain }}{{ config.uri_img }}{{ file.file }}" target="_blank">Exif</a> 
 		{% endif %}
 		{% if config.image_identification_google %}
 			<a href="https://www.google.com/searchbyimage?image_url={{ config.domain|url_encode }}{{ config.uri_img|url_encode }}{{ file.file|url_encode }}" target="_blank">Google</a> 


### PR DESCRIPTION
exif.int21h.win owners forgot to pay their bills, moved to jimpl.com/?url=${} for fetching image Exif data. Thank you Anonymous poster for spotting this.

![image](https://github.com/systemd1337/vichan-plus/assets/154212868/ba85898c-d0e5-45dc-8751-5c6da0b15535)
